### PR TITLE
Added rate limit option to publishAll

### DIFF
--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -215,6 +215,9 @@ protected:
 
   ros::Subscriber m_crossSectional2DMapRequestSub;
 
+  ros::WallDuration m_publishAllRate;
+  ros::WallTime m_lastPublishTime;
+
   OcTreeT* m_octree;
   octomap::KeyRay m_keyRay;  // temp storage for ray casting
   octomap::OcTreeKey m_updateBBXMin;

--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -116,6 +116,11 @@ OctomapServer::OctomapServer(ros::NodeHandle private_nh_)
   private_nh.param("compress_map", m_compressMap, m_compressMap);
   private_nh.param("incremental_2D_projection", m_incrementalUpdate, m_incrementalUpdate);
 
+  double publishRate = 0.1; 
+  private_nh.param("publish_all_rate", publishRate, publishRate );
+  m_publishAllRate = ros::WallDuration( publishRate );
+  m_lastPublishTime = ros::WallTime::now();
+
   if (m_filterGroundPlane && (m_pointcloudMinZ > 0.0 || m_pointcloudMaxZ < 0.0)){
     ROS_WARN_STREAM("You enabled ground filtering but incoming pointclouds will be pre-filtered in ["
               <<m_pointcloudMinZ <<", "<< m_pointcloudMaxZ << "], excluding the ground level z=0. "
@@ -395,8 +400,10 @@ void OctomapServer::insertCloudCallback(const sensor_msgs::PointCloud2::ConstPtr
   double total_elapsed = (ros::WallTime::now() - startTime).toSec();
   ROS_DEBUG("Pointcloud insertion in OctomapServer done (%zu+%zu pts (ground/nonground), %f sec)", pc_ground.size(), pc_nonground.size(), total_elapsed);
 
-  publishAll(cloud->header.stamp);
-
+  if( ( ros::WallTime::now() - m_lastPublishTime ) > m_publishAllRate ) {
+    publishAll(cloud->header.stamp);
+    m_lastPublishTime = ros::WallTime::now();
+  }
 }
 
 void OctomapServer::insertScan(const tf::Point& sensorOriginTf, const PCLPointCloud& ground, const PCLPointCloud& nonground){


### PR DESCRIPTION
While profiling octomap, the "insertScan" method is fairly consistent at <1 ms on each run, publishAll however can drift up to 30 ms + with no new options.  With publish crossSection it approaches 40 ms + and grows with map size.  To try to get things more deterministic I added a 100 ms publish rate to keep CPU usage down.