### PR TITLE
Integrated ROS Time octo. Added Epoch Filtering.

### DIFF
--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -14,7 +14,6 @@ set(PACKAGE_DEPENDENCIES
   octomap_msgs
   dynamic_reconfigure
   nodelet  
-  message_generation
 )
 
 
@@ -32,23 +31,12 @@ include_directories(
   ${OCTOMAP_INCLUDE_DIRS}
 )
 
-## Generate services
-add_service_files(
-  FILES
-  SetEpoch.srv
-)
-
-generate_messages(
-   DEPENDENCIES
-   std_msgs
-)
-
 generate_dynamic_reconfigure_options(cfg/OctomapServer.cfg)
 
 catkin_package(
   INCLUDE_DIRS include ${OCTOMAP_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-  CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES} message_runtime
+  CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES}
   DEPENDS PCL
 )
 

--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PACKAGE_DEPENDENCIES
   octomap_msgs
   dynamic_reconfigure
   nodelet  
+  message_generation
 )
 
 
@@ -31,13 +32,23 @@ include_directories(
   ${OCTOMAP_INCLUDE_DIRS}
 )
 
+## Generate services
+add_service_files(
+  FILES
+  SetEpoch.srv
+)
+
+generate_messages(
+   DEPENDENCIES
+   std_msgs
+)
 
 generate_dynamic_reconfigure_options(cfg/OctomapServer.cfg)
 
 catkin_package(
   INCLUDE_DIRS include ${OCTOMAP_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-  CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES}
+  CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES} message_runtime
   DEPENDS PCL
 )
 
@@ -47,7 +58,7 @@ set(LINK_LIBS
   ${PCL_LIBRARIES}
 )
 
-add_library(${PROJECT_NAME} src/OctomapServer.cpp src/OctomapServerMultilayer.cpp src/TrackingOctomapServer.cpp)
+add_library(${PROJECT_NAME} src/OctomapServer.cpp src/OctomapServerMultilayer.cpp src/TrackingOctomapServer.cpp src/SquareOcTreeStamped.cpp)
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 

--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -74,7 +74,8 @@
 #ifdef COLOR_OCTOMAP_SERVER
 #include <octomap/ColorOcTree.h>
 #elif defined(STAMPED_OCTOMAP_SERVER)
-#include <octomap/OcTreeStamped.h>
+#include <octomap_server/SquareOcTreeStamped.h>
+#include <octomap_server/SetEpoch.h>
 #endif
 
 namespace octomap_server {
@@ -88,7 +89,7 @@ public:
 #elif defined(STAMPED_OCTOMAP_SERVER)
   typedef pcl::PointXYZ PCLPoint;
   typedef pcl::PointCloud<pcl::PointXYZ> PCLPointCloud;
-  typedef octomap::OcTreeStamped OcTreeT;
+  typedef octomap::SquareOcTreeStamped OcTreeT;
 #else
   typedef pcl::PointXYZ PCLPoint;
   typedef pcl::PointCloud<pcl::PointXYZ> PCLPointCloud;
@@ -103,6 +104,9 @@ public:
   virtual bool octomapFullSrv(OctomapSrv::Request  &req, OctomapSrv::GetOctomap::Response &res);
   bool clearBBXSrv(BBXSrv::Request& req, BBXSrv::Response& resp);
   bool resetSrv(std_srvs::Empty::Request& req, std_srvs::Empty::Response& resp);
+#ifdef STAMPED_OCTOMAP_SERVER
+  bool setEpochSrv(SetEpoch::Request& req, SetEpoch::Response& resp); 
+#endif
 
   void OnCrossSectionRequest(const std_msgs::Float32::ConstPtr& request);
   virtual void insertCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud);
@@ -223,6 +227,9 @@ protected:
   message_filters::Subscriber<sensor_msgs::PointCloud2>* m_pointCloudSub;
   tf::MessageFilter<sensor_msgs::PointCloud2>* m_tfPointCloudSub;
   ros::ServiceServer m_octomapBinaryService, m_octomapFullService, m_clearBBXService, m_resetService;
+#ifdef STAMPED_OCTOMAP_SERVER
+  ros::ServiceServer m_setEpochService;
+#endif
   tf::TransformListener m_tfListener;
   boost::recursive_mutex m_config_mutex;
   dynamic_reconfigure::Server<OctomapServerConfig> m_reconfigureServer;

--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -75,7 +75,8 @@
 #include <octomap/ColorOcTree.h>
 #elif defined(STAMPED_OCTOMAP_SERVER)
 #include <octomap_server/SquareOcTreeStamped.h>
-#include <octomap_server/SetEpoch.h>
+#include <std_msgs/Time.h>
+#include <std_msgs/Duration.h>
 #endif
 
 namespace octomap_server {
@@ -105,7 +106,8 @@ public:
   bool clearBBXSrv(BBXSrv::Request& req, BBXSrv::Response& resp);
   bool resetSrv(std_srvs::Empty::Request& req, std_srvs::Empty::Response& resp);
 #ifdef STAMPED_OCTOMAP_SERVER
-  bool setEpochSrv(SetEpoch::Request& req, SetEpoch::Response& resp); 
+  void onSetEpoch(const std_msgs::Time::ConstPtr& epoch);
+  void onSetDegradeThresh(const std_msgs::Duration::ConstPtr& thresh);
 #endif
 
   void OnCrossSectionRequest(const std_msgs::Float32::ConstPtr& request);
@@ -228,7 +230,7 @@ protected:
   tf::MessageFilter<sensor_msgs::PointCloud2>* m_tfPointCloudSub;
   ros::ServiceServer m_octomapBinaryService, m_octomapFullService, m_clearBBXService, m_resetService;
 #ifdef STAMPED_OCTOMAP_SERVER
-  ros::ServiceServer m_setEpochService;
+  ros::Subscriber m_setEpochSub, m_setDegradeThreshSub;
 #endif
   tf::TransformListener m_tfListener;
   boost::recursive_mutex m_config_mutex;
@@ -276,7 +278,7 @@ protected:
   bool m_filterSpeckles;
 
   bool m_simpleGroundFilter;
-  unsigned int m_time_thresh;
+  uint32_t m_time_thresh;
 
   bool m_filterGroundPlane;
   double m_groundFilterDistance;

--- a/octomap_server/include/octomap_server/SquareOcTreeStamped.h
+++ b/octomap_server/include/octomap_server/SquareOcTreeStamped.h
@@ -60,20 +60,20 @@ public:
   }
 
   // timestamp
-  inline unsigned int getTimestamp() const {
+  inline uint32_t getTimestamp() const {
     return timestamp;
   }
 
   inline void updateTimestamp() {
-    timestamp = *time;
+    timestamp = time;
   }
 
-  inline void setTimestamp(unsigned int t) {
+  inline void setTimestamp(uint32_t t) {
     timestamp = t;
   }
 
-  inline void setTime(unsigned int t) {
-    *time = t;
+  inline void setTime(uint32_t t) {
+    time = t;
   }
 
   inline void updateOccupancyChildren() {
@@ -82,14 +82,14 @@ public:
   }
 
 protected:
-  unsigned int timestamp;
-  static std::shared_ptr<unsigned int> time;
+  uint32_t timestamp;
+  static uint32_t time;
 };
 
 // tree definition
 class SquareOcTreeStamped : public OccupancyOcTreeBase<SquareOcTreeNodeStamped> {
 private:
-  unsigned int time_last_updated;
+  uint32_t time_last_updated;
 
 public:
   // Default Constructor
@@ -104,13 +104,13 @@ public:
     return "SquareOcTreeStamped";
   }
 
-  unsigned int getLastUpdateTime();
-  void updateTime(unsigned int t);
+  uint32_t getLastUpdateTime();
+  void updateTime(uint32_t t);
 
   // Probabilistically degrades all occupied nodes last updated more than time_thresh seconds ago
-  void degradeOutdatedNodes(unsigned int time_thresh, unsigned int current_time);
+  void degradeOutdatedNodes(uint32_t time_thresh, uint32_t current_time);
   // Removes all nodes last updated before the given epoch
-  void removeStaleNodes(unsigned int epoch);
+  void removeStaleNodes(uint32_t epoch);
   // Updates the log odds of a node by update
   void updateNodeLogOdds(SquareOcTreeNodeStamped* node, const float& update) const override;
 

--- a/octomap_server/include/octomap_server/SquareOcTreeStamped.h
+++ b/octomap_server/include/octomap_server/SquareOcTreeStamped.h
@@ -1,0 +1,141 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Square Robot, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Square Robot, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_EXTERNAL_OCTOMAP_MAPPING_OCTOMAP_SERVER_INCLUDE_OCTOMAP_SERVER_SQUAREOCTREESTAMPED_H_
+#define SRC_EXTERNAL_OCTOMAP_MAPPING_OCTOMAP_SERVER_INCLUDE_OCTOMAP_SERVER_SQUAREOCTREESTAMPED_H_
+
+#include <octomap/OcTreeNode.h>
+#include <octomap/OccupancyOcTreeBase.h>
+#include <memory>
+
+namespace octomap {
+
+// node definition
+class SquareOcTreeNodeStamped : public OcTreeNode {
+public:
+  SquareOcTreeNodeStamped() : OcTreeNode(), timestamp(0) {
+  }
+
+  SquareOcTreeNodeStamped(const SquareOcTreeNodeStamped& rhs) : OcTreeNode(rhs), timestamp(rhs.timestamp) {
+  }
+
+  bool operator==(const SquareOcTreeNodeStamped& rhs) const {
+    return (rhs.value == value && rhs.timestamp == timestamp);
+  }
+
+  void copyData(const SquareOcTreeNodeStamped& from) {
+    OcTreeNode::copyData(from);
+    timestamp = from.getTimestamp();
+  }
+
+  // timestamp
+  inline unsigned int getTimestamp() const {
+    return timestamp;
+  }
+
+  inline void updateTimestamp() {
+    timestamp = *time;
+  }
+
+  inline void setTimestamp(unsigned int t) {
+    timestamp = t;
+  }
+
+  inline void setTime(unsigned int t) {
+    *time = t;
+  }
+
+  inline void updateOccupancyChildren() {
+    this->setLogOdds(this->getMaxChildLogOdds());  // conservative
+    updateTimestamp();
+  }
+
+protected:
+  unsigned int timestamp;
+  static std::shared_ptr<unsigned int> time;
+};
+
+// tree definition
+class SquareOcTreeStamped : public OccupancyOcTreeBase<SquareOcTreeNodeStamped> {
+private:
+  unsigned int time_last_updated;
+
+public:
+  // Default Constructor
+  explicit SquareOcTreeStamped(double resolution);
+
+  // Virtual Constructor
+  SquareOcTreeStamped* create() const {
+    return new SquareOcTreeStamped(resolution);
+  }
+
+  std::string getTreeType() const {
+    return "SquareOcTreeStamped";
+  }
+
+  unsigned int getLastUpdateTime();
+  void updateTime(unsigned int t);
+
+  // Probabilistically degrades all occupied nodes last updated more than time_thresh seconds ago
+  void degradeOutdatedNodes(unsigned int time_thresh, unsigned int current_time);
+  // Removes all nodes last updated before the given epoch
+  void removeStaleNodes(unsigned int epoch);
+  // Updates the log odds of a node by update
+  void updateNodeLogOdds(SquareOcTreeNodeStamped* node, const float& update) const override;
+
+protected:
+  /**
+   * Static member object which ensures that this OcTree's prototype
+   * ends up in the classIDMapping only once. You need this as a
+   * static member in any derived octree class in order to read .ot
+   * files through the AbstractOcTree factory. You should also call
+   * ensureLinking() once from the constructor.
+   */
+  class StaticMemberInitializer {
+  public:
+    StaticMemberInitializer() {
+      SquareOcTreeStamped* tree = new SquareOcTreeStamped(0.1);
+      tree->clearKeyRays();
+      AbstractOcTree::registerTreeType(tree);
+    }
+    void ensureLinking() {
+    }
+  };
+  /// to ensure static initialization (only once)
+  static StaticMemberInitializer SquareOcTreeStampedMemberInit;
+};
+
+}  // namespace octomap
+
+#endif  // SRC_EXTERNAL_OCTOMAP_MAPPING_OCTOMAP_SERVER_INCLUDE_OCTOMAP_SERVER_SQUAREOCTREESTAMPED_H_

--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -31,7 +31,6 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
-  <build_depend>message_generation</build_depend>
   
 
  <run_depend>roscpp</run_depend>
@@ -48,8 +47,6 @@
  <run_depend>dynamic_reconfigure</run_depend>
  <run_depend>nodelet</run_depend>
  <run_depend>libpcl-all</run_depend>
- <run_depend>message_runtime</run_depend>
- <run_depend>message_generation</run_depend>
  
 </package>
 

--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -31,6 +31,8 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>message_generation</build_depend>
+  
 
  <run_depend>roscpp</run_depend>
  <run_depend>visualization_msgs</run_depend>
@@ -46,6 +48,8 @@
  <run_depend>dynamic_reconfigure</run_depend>
  <run_depend>nodelet</run_depend>
  <run_depend>libpcl-all</run_depend>
+ <run_depend>message_runtime</run_depend>
+ <run_depend>message_generation</run_depend>
  
 </package>
 

--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -308,7 +308,7 @@ void OctomapServer::OnCrossSectionRequest(const std_msgs::Float32::ConstPtr& req
 void OctomapServer::insertCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud){
   ros::WallTime startTime = ros::WallTime::now();
 #ifdef STAMPED_OCTOMAP_SERVER
-  m_octree->updateTime(static_cast<unsigned int>(ros::Time::now().toSec()));
+  m_octree->updateTime(static_cast<uint32_t>(ros::Time::now().toSec()));
 #endif
 
   //
@@ -417,7 +417,7 @@ void OctomapServer::insertCloudCallback(const sensor_msgs::PointCloud2::ConstPtr
   insertScan(sensorToWorldTf.getOrigin(), pc_ground, pc_nonground);
 #ifdef STAMPED_OCTOMAP_SERVER
   if( m_time_thresh > 0 ) {
-    m_octree->degradeOutdatedNodes( m_time_thresh, static_cast<unsigned int>(ros::Time::now().toSec()));
+    m_octree->degradeOutdatedNodes( m_time_thresh, static_cast<uint32_t>(ros::Time::now().toSec()));
   }
 #endif
 

--- a/octomap_server/src/SquareOcTreeStamped.cpp
+++ b/octomap_server/src/SquareOcTreeStamped.cpp
@@ -1,0 +1,81 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Square Robot, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Square Robot, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "octomap_server/SquareOcTreeStamped.h"
+
+namespace octomap {
+std::shared_ptr<unsigned int> SquareOcTreeNodeStamped::time = std::make_shared<unsigned int>(0);
+
+SquareOcTreeStamped::SquareOcTreeStamped(double in_resolution)
+  : OccupancyOcTreeBase<SquareOcTreeNodeStamped>(in_resolution) {
+  SquareOcTreeStampedMemberInit.ensureLinking();
+}
+
+unsigned int SquareOcTreeStamped::getLastUpdateTime() {
+  return time_last_updated;
+}
+
+void SquareOcTreeStamped::updateTime(unsigned int t) {
+  time_last_updated = t;
+  if (this->root) {
+    root->setTime(t);
+  }
+}
+
+void SquareOcTreeStamped::degradeOutdatedNodes(unsigned int time_thres, unsigned int current_time) {
+  for (leaf_iterator it = this->begin_leafs(), end = this->end_leafs(); it != end; ++it) {
+    if (this->isNodeOccupied(*it) && ((current_time - it->getTimestamp()) > time_thres)) {
+      OccupancyOcTreeBase<SquareOcTreeNodeStamped>::updateNodeLogOdds(&*it, prob_miss_log);
+    }
+  }
+}
+
+void SquareOcTreeStamped::removeStaleNodes(unsigned int epoch) {
+  std::deque<OcTreeKey> keys_to_remove;
+  for (leaf_iterator it = this->begin_leafs(); it != this->end_leafs(); ++it) {
+    if (it->getTimestamp() < epoch) {
+      keys_to_remove.push_back(it.getKey());
+    }
+  }
+  for (auto k : keys_to_remove) {
+    this->deleteNode(k);
+  }
+}
+
+void SquareOcTreeStamped::updateNodeLogOdds(SquareOcTreeNodeStamped* node, const float& update) const {
+  OccupancyOcTreeBase<SquareOcTreeNodeStamped>::updateNodeLogOdds(node, update);
+  node->updateTimestamp();
+}
+
+SquareOcTreeStamped::StaticMemberInitializer SquareOcTreeStamped::SquareOcTreeStampedMemberInit;
+}  // namespace octomap

--- a/octomap_server/src/SquareOcTreeStamped.cpp
+++ b/octomap_server/src/SquareOcTreeStamped.cpp
@@ -34,25 +34,25 @@
 #include "octomap_server/SquareOcTreeStamped.h"
 
 namespace octomap {
-std::shared_ptr<unsigned int> SquareOcTreeNodeStamped::time = std::make_shared<unsigned int>(0);
+uint32_t SquareOcTreeNodeStamped::time = 0;
 
 SquareOcTreeStamped::SquareOcTreeStamped(double in_resolution)
   : OccupancyOcTreeBase<SquareOcTreeNodeStamped>(in_resolution) {
   SquareOcTreeStampedMemberInit.ensureLinking();
 }
 
-unsigned int SquareOcTreeStamped::getLastUpdateTime() {
+uint32_t SquareOcTreeStamped::getLastUpdateTime() {
   return time_last_updated;
 }
 
-void SquareOcTreeStamped::updateTime(unsigned int t) {
+void SquareOcTreeStamped::updateTime(uint32_t t) {
   time_last_updated = t;
   if (this->root) {
     root->setTime(t);
   }
 }
 
-void SquareOcTreeStamped::degradeOutdatedNodes(unsigned int time_thres, unsigned int current_time) {
+void SquareOcTreeStamped::degradeOutdatedNodes(uint32_t time_thres, uint32_t current_time) {
   for (leaf_iterator it = this->begin_leafs(), end = this->end_leafs(); it != end; ++it) {
     if (this->isNodeOccupied(*it) && ((current_time - it->getTimestamp()) > time_thres)) {
       OccupancyOcTreeBase<SquareOcTreeNodeStamped>::updateNodeLogOdds(&*it, prob_miss_log);
@@ -60,7 +60,7 @@ void SquareOcTreeStamped::degradeOutdatedNodes(unsigned int time_thres, unsigned
   }
 }
 
-void SquareOcTreeStamped::removeStaleNodes(unsigned int epoch) {
+void SquareOcTreeStamped::removeStaleNodes(uint32_t epoch) {
   std::deque<OcTreeKey> keys_to_remove;
   for (leaf_iterator it = this->begin_leafs(); it != this->end_leafs(); ++it) {
     if (it->getTimestamp() < epoch) {

--- a/octomap_server/srv/SetEpoch.srv
+++ b/octomap_server/srv/SetEpoch.srv
@@ -1,0 +1,3 @@
+uint32 epoch
+---
+# No response

--- a/octomap_server/srv/SetEpoch.srv
+++ b/octomap_server/srv/SetEpoch.srv
@@ -1,3 +1,0 @@
-uint32 epoch
----
-# No response


### PR DESCRIPTION
## ros::Time Integration
To keep the dependency on ros out of the new `SquareStampedOcTree` classes I used a static `shared_ptr` in the new `SquareOcTreeNodeStamped` class, who's content is updated to `ros::Time::now` on each invocation of the onScan callback. 

Unfortunately, this cant be done in a functional style by parameter passing without edits to octomap itself  because we would need to pass the current time into `updateOccupancyChildren` which is invoked by its parameterless interface in a few spots inside the octomap base code [1](https://github.com/OctoMap/octomap/blob/4e1e818529c2f3d0872f5ba7c8383e25752aba7e/octomap/include/octomap/OccupancyOcTreeBase.hxx#L400) [2](https://github.com/OctoMap/octomap/blob/4e1e818529c2f3d0872f5ba7c8383e25752aba7e/octomap/include/octomap/OccupancyOcTreeBase.hxx#L464) [3](https://github.com/OctoMap/octomap/blob/4e1e818529c2f3d0872f5ba7c8383e25752aba7e/octomap/include/octomap/OccupancyOcTreeBase.hxx#L513).

I know static class members isnt common practice, but it felt applicable here. Thoughts?


## Epoch Handling
Reference [here](https://github.com/OctoMap/octomap/issues/283).

I left `degradeOutdatedNodes` almost as it was in case we want to still use it, but also because using it to remove outdated nodes will leave in place all the freespace nodes from before the given `epoch` which of course propagates onto our costmap layers. Instead I opted to add the new `removeStaleNodes` which fully deletes (de-allocates memory as well) nodes which is the only way to "reset" nodes to an "unknown" state [ref (answer is by author of octomap)](https://answers.ros.org/question/53160/update-node-back-to-unknown-in-octomap/).

I am not trilled about adding the new service in this package, but at the moment it appears the other option would be to fork `octomap_msgs` and add it there. 