### PR TITLE
Sensor Models

### DIFF
--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -137,7 +137,7 @@ protected:
   * @param ground scan endpoints on the ground plane (only clear space)
   * @param nonground all other endpoints (clear up to occupied endpoint)
   */
-  virtual void insertScan(const tf::Point& sensorOrigin, const PCLPointCloud& ground, const PCLPointCloud& nonground);
+  virtual void insertScan(const tf::Point& sensorOrigin, const PCLPointCloud& ground, const PCLPointCloud& nonground, std::string sensor_frame="");
 
   /// label the input cloud "pc" into ground and nonground. Should be in the robot's fixed frame (not world!)
   void filterGroundPlane(const PCLPointCloud& pc, PCLPointCloud& ground, PCLPointCloud& nonground) const;
@@ -274,6 +274,7 @@ protected:
   double m_zCrossSectionLocation;
 
   bool m_initConfig;
+  std::map<std::string, double> m_sensor_frame_hit_prob, m_sensor_frame_miss_prob;
 
   // downprojected 2D map:
   bool m_incrementalUpdate;


### PR DESCRIPTION
Extended `OctomapServer` to enable per-frame sensor configurations.
Sensor models are read from param server as a map from the sensor's frame_id to their probability for a hit or probability for a miss. 

Suggested sensor models
| Sensor | P(hit) | P(miss) |
| --- | --- | --- |
| Isa | 0.58 | 0.4 |
| Gemini | 0.65 | 0.3 |

White a occupancy threshold of `0.7`

This results in (at minimum) 3 Isa hits for a node to be occupied, or 1 Isa and 1 Gemini) and for a occupied cell with `p=0.8` it takes 2 isa misses or 1 Gemini miss to reset the cell to freespace.

This approach is very simple, but lacks in that there is no way to include intensities when preforming Node updates from scans, as the probabilities per sensor are not modifiable dynamically for each point in the sensor's scan. 

Example Configuration
```
sensor_model:
    default_hit: 0.7
    default_miss: 0.4
    occupancy_thresh: 0.7
    probs_hit:
        isa500_sensor: 0.58
        tritech_gemini_base: 0.65

    probs_miss:
        isa500_sensor: 0.4
        tritech_gemini_base: 0.3
```
        