### PR TITLE
Apply tank-bounds pointcloud filters in world frame

### DIFF
--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -1386,7 +1386,7 @@ void OctomapServer::reconfigureCallback(octomap_server::OctomapServerConfig& con
     m_fixedSizeX = config.map_fixed_x_size;
     m_fixedSizeY = config.map_fixed_y_size;
     m_fixedOriginX = config.map_fixed_x_origin;
-    m_fixedOriginY = config.map_fixed_x_origin;
+    m_fixedOriginY = config.map_fixed_y_origin;
 
     // DNR 6-16-23: This is a rather ominous comment which I don't completely understand, but dynamic
     //              reconfigure doesn't work for other parameters on startup if this is returning here

--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -387,14 +387,14 @@ void OctomapServer::insertCloudCallback(const sensor_msgs::PointCloud2::ConstPtr
     pcl::transformPointCloud(pc_ground, pc_ground, baseToWorld);
     pcl::transformPointCloud(pc_nonground, pc_nonground, baseToWorld);
   } else if(m_simpleGroundFilter) {
-    // limit to octomap_tank_relay params
+    // directly transform to map frame:
+    pcl::transformPointCloud(pc, pc, sensorToWorld);
+
+    // limit to octomap_tank_relay params (world frame)
     pass_x.setInputCloud(pc.makeShared());
     pass_x.filter(pc);
     pass_y.setInputCloud(pc.makeShared());
     pass_y.filter(pc);
-
-    // directly transform to map frame:
-    pcl::transformPointCloud(pc, pc, sensorToWorld);
 
     // filter for just nonground in world frame
     pass_z.setFilterLimits(m_groundFilterDistance, m_pointcloudMaxZ);


### PR DESCRIPTION
Part of squarerobot/utbot#4340.  Each fix is its own commit.

Implementation details:

1. On the `simple_ground_filter` path (what every vehicle runs), `pass_x`/`pass_y` (the `pointcloud_min/max_x/y` limits) ran before `transformPointCloud(sensorToWorld)`, so they evaluated in the sensor frame where an ISA point is (x=range, y=0) -> every point passed, and the tank bounds `octomap_tankinfo_relay` has pushed since 2019 have never done anything.  Moved the two filters after the transform so the limits are world-frame, same as the stock no-ground-filter path and the same place the z filter already runs.  4-line reorder, no other semantic change.
2. Fixed-map y origin was read from `map_fixed_x_origin` (x/y typo).  No behavior change today since the relay sends identical x/y origins, but wrong for any asymmetric fixed map.

Why: multipath (robot self-echo, floor/wall double bounces) arrives inside the ISA listening window (`dynamic_config` caps it at tank diameter), so it can't be separated from real far-shell returns by range.  It can by world position.  On the tank 103 mission, 42% of final-map occupied cells sat outside the shell (out to r=41.5m in a r=15.24m tank), inflating the octree bounding box to ~84m for a 33m tank and pegging an MVC core (octomap silently dropped ~1 in 5 sonar pings all mission, `cloud_in` 5Hz vs octomap outputs 4Hz).

Benchmarks - A/B replay through `octomap_server_multilayer`, stock vs this reorder + a `+/-1.2R` world box (the values squarerobot/utbot#4341 makes the relay send).  Same machine, same 2x rate, all 8 output topics subscribed, fresh map both runs:

| metric | stock | this PR + box |
|---|---|---|
| CPU per scan | 224ms | 104ms (-53%) |
| scans processed (of 11,021 offered) | 4,913 (44.6%) | 9,102 (82.6%) |
| final `octomap_full` | 2.37MB | 1.34MB (-44%) |
| final `octomap_binary` | 287KB | 139KB (-51%) |
| RSS | 97MB | 76MB |
| CPU rate over run | 88 -> 103% of a core (pegged) | 44 -> 102% |

At the vehicle's real 5Hz input that's ~1.1 cores -> ~0.5, so the MVC core un-pegs and the scan dropping stops.  `octomap_full` is ~80% of `mission_extended` recorded bytes, so -44% there is roughly a third off bag size plus the matching bagger CPU (LZ4) and disk writes.

Test machine: i7-13700H (20 threads) / 32GB dev laptop, inside the `squarerobot-ros1-dev` container.  Absolute ms/scan will differ on the MVC, the ratios are the signal (the stock run reproduces the exact pegged-core + dropped-scan behavior seen in the mission bags).

Bags: `vat:squarerobot-vat-staging/.datafile/siteowners/Valero/Mckee/103/2026-07-07/tankinspection_561/ROS files`, files `mission_extended_2026-07-07-19-18-40_3` through `mission_extended_2026-07-07-19-42-44_5` (replayed `/utbot/vehicle/cloud_in` + `/tf` + `/tf_static`, launch params from `sr_vehicle_common/launch/octomap.launch`).

Pros:

- ghosts rejected at insertion, so the free-space rays toward them are never cast either (that's most of the CPU win)
- map extent bounded by the tank -> smaller tree, smaller bags, un-pegged core, full 5Hz map updates
- the relay plumbing finally does what it was written to do, no new mechanism

Cons / limitations:

- box is square, tank is round: corner-direction ghosts inside `+/-1.2R` still get through (small residual, already included in the numbers above)
- a hard world-frame clamp trusts world origin = tank center, same assumption the existing `map_fixed_*` params already make
- points are transformed before filtering now, trivial at 1 pt/scan but worth knowing if a dense sensor ever feeds this

NOTE - do not bump the utbot `.rosinstall` pin to this until squarerobot/utbot#4341 merges.  The relay currently sends `[0, 1.2*diameter]`, which would clip 3/4 of the tank once this filter works; #4341 fixes the values and does the pin bump atomically.